### PR TITLE
Update link to countdown.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [Countdown's documentation](http://countdownjs.org/readme.html) for descript
 ##Getting set up
 
 ###Browser
-Grab [moment.js](https://raw.github.com/moment/moment/2.0.0/min/moment.min.js), [countdown.js](https://bitbucket.org/mckamey/countdown.js/raw/tip/countdown.min.js), and [moment-countdown.js](https://raw.github.com/icambron/moment-countdown/master/dist/moment-countdown.min.js). Then inside your header:
+Grab [moment.js](https://raw.github.com/moment/moment/2.0.0/min/moment.min.js), [countdown.js](https://github.com/mckamey/countdownjs/raw/master/countdown.min.js), and [moment-countdown.js](https://raw.github.com/icambron/moment-countdown/master/dist/moment-countdown.min.js). Then inside your header:
 
 ```html
 <script src="moment.min.js"></script>


### PR DESCRIPTION
The Bitbucket repo for countdown.js no longer exists. This updates the link in the readme to point at the new GitHub repo.